### PR TITLE
Improve test coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,4 @@
+coverage:
+  ignore:
+    - Tests/.*
+

--- a/MiniDOM.xcodeproj/project.pbxproj
+++ b/MiniDOM.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		C54FA8EA1E763CE6009EEA73 /* MiniDOM.h in Headers */ = {isa = PBXBuildFile; fileRef = C54FA8E61E763CE6009EEA73 /* MiniDOM.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C54FA8EB1E763CE6009EEA73 /* MiniDOM.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54FA8E71E763CE6009EEA73 /* MiniDOM.swift */; };
 		C54FA8EC1E763CE6009EEA73 /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54FA8E81E763CE6009EEA73 /* Parser.swift */; };
+		C56856EA1E88BDF40058EF81 /* ParserNamespaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C56856E91E88BDF40058EF81 /* ParserNamespaceTests.swift */; };
 		C5C88DD21E7C28C700CEDDA8 /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5C88DD11E7C28C700CEDDA8 /* Log.swift */; };
 		C5C88DD41E7C861E00CEDDA8 /* FormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5C88DD31E7C861E00CEDDA8 /* FormatterTests.swift */; };
 		C5C88DD71E7C869500CEDDA8 /* XCTestCase+ParseUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5C88DD51E7C867900CEDDA8 /* XCTestCase+ParseUtil.swift */; };
@@ -67,6 +68,7 @@
 		C54FA8E81E763CE6009EEA73 /* Parser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Parser.swift; sourceTree = "<group>"; };
 		C54FA8EF1E763CEE009EEA73 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C54FA8F41E763D42009EEA73 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
+		C56856E91E88BDF40058EF81 /* ParserNamespaceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParserNamespaceTests.swift; sourceTree = "<group>"; };
 		C5C88DD11E7C28C700CEDDA8 /* Log.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Log.swift; sourceTree = "<group>"; };
 		C5C88DD31E7C861E00CEDDA8 /* FormatterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormatterTests.swift; sourceTree = "<group>"; };
 		C5C88DD51E7C867900CEDDA8 /* XCTestCase+ParseUtil.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+ParseUtil.swift"; sourceTree = "<group>"; };
@@ -174,11 +176,12 @@
 				C5C88DD31E7C861E00CEDDA8 /* FormatterTests.swift */,
 				C54FA8EF1E763CEE009EEA73 /* Info.plist */,
 				C5EB9CEB1E7CEE0B00198F5F /* LogTests.swift */,
+				C532F9B91E82128E00FEAD1A /* ParserCreationTests.swift */,
 				C5EB9CEF1E7CF46800198F5F /* ParserErrorTests.swift */,
+				C56856E91E88BDF40058EF81 /* ParserNamespaceTests.swift */,
 				C5C88DDA1E7C89BD00CEDDA8 /* ParserPlistTests.swift */,
 				C5EB9CED1E7CF12D00198F5F /* ParserResultTests.swift */,
 				C5C88DD81E7C889200CEDDA8 /* ParserSimpleTests.swift */,
-				C532F9B91E82128E00FEAD1A /* ParserCreationTests.swift */,
 				C5EB9CE31E7CC85700198F5F /* PathSimpleTests.swift */,
 				C5EB9CE51E7CC94600198F5F /* StringWhitespaceTests.swift */,
 				C5D2BCF01E773C26001FF7E8 /* TestData */,
@@ -424,6 +427,7 @@
 			files = (
 				C5EB9CF21E7CF5B900198F5F /* VisitorTests.swift in Sources */,
 				C5EB9CF01E7CF46800198F5F /* ParserErrorTests.swift in Sources */,
+				C56856EA1E88BDF40058EF81 /* ParserNamespaceTests.swift in Sources */,
 				C5C88DD91E7C889200CEDDA8 /* ParserSimpleTests.swift in Sources */,
 				C5EB9CEE1E7CF12D00198F5F /* ParserResultTests.swift in Sources */,
 				C5EB9CEA1E7CCB1300198F5F /* RSSTests.swift in Sources */,

--- a/Sources/MiniDOM.swift
+++ b/Sources/MiniDOM.swift
@@ -337,18 +337,6 @@ public final class Element: ParentNode {
     public var tagName: String
 
     /**
-     If namespace processing is turned on, contains the URI for the current
-     namespace.
-     */
-    public var namespaceURI: String?
-
-    /**
-     If namespace processing is turned on, contains the qualified name for the
-     current namespace.
-     */
-    public var qualifiedName: String?
-
-    /**
      A dictionary that contains any attributes associated with the element.
      Keys are the names of attributes, and values are attribute values.
      */
@@ -362,20 +350,12 @@ public final class Element: ParentNode {
      - parameter tagName: A string that is the name of an element (in its start
      tag).
 
-     - parameter namespaceURI: If namespace processing is turned on, contains
-     the URI for the current namespace.
-
-     - parameter qualifiedName: If namespace processing is turned on, contains
-     the qualified name for the current namespace.
-
      - parameter attributes: A dictionary that contains any attributes
      associated with the element. Keys are the names of attributes, and values
      are attribute values.
      */
-    public init(tagName: String, namespaceURI: String?, qualifiedName: String?, attributes: [String : String]) {
+    public init(tagName: String, attributes: [String : String]) {
         self.tagName = tagName
-        self.namespaceURI = namespaceURI
-        self.qualifiedName = qualifiedName
         self.attributes = attributes
     }
 }

--- a/Sources/Parser.swift
+++ b/Sources/Parser.swift
@@ -200,7 +200,7 @@ public class Parser {
     }
 }
 
-fileprivate class NodeStack: NSObject, XMLParserDelegate {
+class NodeStack: NSObject, XMLParserDelegate {
     private let log = Log(level: .warn)
 
     private var stack: ArraySlice<Node> = []

--- a/Sources/Parser.swift
+++ b/Sources/Parser.swift
@@ -113,12 +113,7 @@ public class Parser {
      - returns: An initialized `Parser` object or `nil` if an error occurs.
      */
     public convenience init?(contentsOf url: URL, shouldProcessNamespaces: Bool = false) {
-        guard let parser = XMLParser(contentsOf: url) else {
-            return nil
-        }
-
-        parser.shouldProcessNamespaces = shouldProcessNamespaces
-        self.init(parser: parser)
+        self.init(parser: XMLParser(contentsOf: url), shouldProcessNamespaces: shouldProcessNamespaces)
     }
 
     /**
@@ -136,11 +131,7 @@ public class Parser {
      - returns: An initialized `Parser` object or `nil` if an error occurs.
      */
     public convenience init?(string: String, encoding: String.Encoding = .utf8, shouldProcessNamespaces: Bool = false) {
-        guard let data = string.data(using: encoding) else {
-            return nil
-        }
-
-        self.init(data: data, shouldProcessNamespaces: shouldProcessNamespaces)
+        self.init(data: string.data(using: encoding), shouldProcessNamespaces: shouldProcessNamespaces)
     }
 
     /**
@@ -155,11 +146,12 @@ public class Parser {
      
      - returns: An initialized `Parser` object.
      */
-    public convenience init(data: Data, shouldProcessNamespaces: Bool = false) {
-        let parser = XMLParser(data: data)
-        parser.shouldProcessNamespaces = shouldProcessNamespaces
+    public convenience init?(data: Data?, shouldProcessNamespaces: Bool = false) {
+        guard let data = data else {
+            return nil
+        }
 
-        self.init(parser: parser)
+        self.init(parser: XMLParser(data: data), shouldProcessNamespaces: shouldProcessNamespaces)
     }
 
     /**
@@ -175,15 +167,17 @@ public class Parser {
      
      - returns: An initialized `Parser` object.
      */
-    public convenience init(stream: InputStream, shouldProcessNamespaces: Bool = false) {
-        let parser = XMLParser(stream: stream)
-        parser.shouldProcessNamespaces = shouldProcessNamespaces
-
-        self.init(parser: parser)
+    public convenience init?(stream: InputStream, shouldProcessNamespaces: Bool = false) {
+        self.init(parser: XMLParser(stream: stream), shouldProcessNamespaces: shouldProcessNamespaces)
     }
 
-    private init(parser: XMLParser) {
+    init?(parser: XMLParser?, shouldProcessNamespaces: Bool = false) {
+        guard let parser = parser else {
+            return nil
+        }
+
         self.parser = parser
+        self.parser.shouldProcessNamespaces = shouldProcessNamespaces
     }
 
     /**

--- a/Sources/Parser.swift
+++ b/Sources/Parser.swift
@@ -100,20 +100,17 @@ public class Parser {
         case unspecifiedError
     }
 
+
     /**
      Initializes a parser with the XML content referenced by the given URL.
      
      - parameter url: A `URL` object specifying a URL. The URL must be fully 
      qualified and refer to a scheme that is supported by the `URL` type.
-     
-     - parameter shouldProcessNamespaces: A Boolean value that determines
-     whether the parser reports the prefixes indicating the scope of namespace 
-     declarations.
 
      - returns: An initialized `Parser` object or `nil` if an error occurs.
      */
-    public convenience init?(contentsOf url: URL, shouldProcessNamespaces: Bool = false) {
-        self.init(parser: XMLParser(contentsOf: url), shouldProcessNamespaces: shouldProcessNamespaces)
+    public convenience init?(contentsOf url: URL) {
+        self.init(parser: XMLParser(contentsOf: url))
     }
 
     /**
@@ -123,15 +120,11 @@ public class Parser {
      - parameter string: A `String` object containing XML markup.
 
      - parameter encoding: The encoding of the `String` object.
-     
-     - parameter shouldProcessNamespaces: A Boolean value that determines
-     whether the parser reports the prefixes indicating the scope of namespace
-     declarations.
-     
+
      - returns: An initialized `Parser` object or `nil` if an error occurs.
      */
-    public convenience init?(string: String, encoding: String.Encoding = .utf8, shouldProcessNamespaces: Bool = false) {
-        self.init(data: string.data(using: encoding), shouldProcessNamespaces: shouldProcessNamespaces)
+    public convenience init?(string: String, encoding: String.Encoding = .utf8) {
+        self.init(data: string.data(using: encoding))
     }
 
     /**
@@ -139,19 +132,15 @@ public class Parser {
      object.
 
      - parameter data: A `Data` object containing XML markup.
-    
-     - parameter shouldProcessNamespaces: A Boolean value that determines
-     whether the parser reports the prefixes indicating the scope of namespace
-     declarations.
-     
+
      - returns: An initialized `Parser` object.
      */
-    public convenience init?(data: Data?, shouldProcessNamespaces: Bool = false) {
+    public convenience init?(data: Data?) {
         guard let data = data else {
             return nil
         }
 
-        self.init(parser: XMLParser(data: data), shouldProcessNamespaces: shouldProcessNamespaces)
+        self.init(parser: XMLParser(data: data))
     }
 
     /**
@@ -160,24 +149,19 @@ public class Parser {
      - parameter stream: The input stream. The content is incrementally loaded 
      from the specified stream and parsed. The `Parser` will open the stream, 
      and synchronously read from it without scheduling it.
-     
-     - parameter shouldProcessNamespaces: A Boolean value that determines
-     whether the parser reports the prefixes indicating the scope of namespace
-     declarations.
-     
+
      - returns: An initialized `Parser` object.
      */
-    public convenience init?(stream: InputStream, shouldProcessNamespaces: Bool = false) {
-        self.init(parser: XMLParser(stream: stream), shouldProcessNamespaces: shouldProcessNamespaces)
+    public convenience init?(stream: InputStream) {
+        self.init(parser: XMLParser(stream: stream))
     }
 
-    init?(parser: XMLParser?, shouldProcessNamespaces: Bool = false) {
+    init?(parser: XMLParser?) {
         guard let parser = parser else {
             return nil
         }
 
         self.parser = parser
-        self.parser.shouldProcessNamespaces = shouldProcessNamespaces
     }
 
     /**
@@ -233,12 +217,12 @@ class NodeStack: NSObject, XMLParserDelegate {
     }
 
     func parser(_ parser: XMLParser, didStartElement elementName: String, namespaceURI: String?, qualifiedName qName: String?, attributes attributeDict: [String : String] = [:]) {
-        log.debug("elementName=\(elementName) namespaceURI=\(namespaceURI) qualifiedName=\(qName), attributes=\(attributeDict)")
-        stack.append(Element(tagName: elementName, namespaceURI: namespaceURI, qualifiedName: qName, attributes: attributeDict))
+        log.debug("elementName=\(elementName) attributes=\(attributeDict)")
+        stack.append(Element(tagName: elementName, attributes: attributeDict))
     }
 
     func parser(_ parser: XMLParser, didEndElement elementName: String, namespaceURI: String?, qualifiedName qName: String?) {
-        log.debug("elementName=\(elementName) namespaceURI=\(namespaceURI) qualifiedName=\(qName)")
+        log.debug("elementName=\(elementName)")
         popAndAppendToTopOfStack()
     }
 

--- a/Tests/MiniDOMTests/ParserCreationTests.swift
+++ b/Tests/MiniDOMTests/ParserCreationTests.swift
@@ -18,9 +18,10 @@
 //
 
 import Foundation
-import MiniDOM
 import Nimble
 import XCTest
+
+@testable import MiniDOM
 
 class ParserCreationTests: XCTestCase {
 
@@ -74,5 +75,15 @@ class ParserCreationTests: XCTestCase {
 
         let inputStreamParser = Parser(stream: inputStream)
         validateResults(from: inputStreamParser)
+    }
+
+    func testCreateWithNilData() {
+        let parser = Parser(data: nil)
+        expect(parser).to(beNil())
+    }
+
+    func testCreateWithNilParser() {
+        let parser = Parser(parser: nil)
+        expect(parser).to(beNil())
     }
 }

--- a/Tests/MiniDOMTests/ParserErrorTests.swift
+++ b/Tests/MiniDOMTests/ParserErrorTests.swift
@@ -18,9 +18,10 @@
 //
 
 import Foundation
-import MiniDOM
 import Nimble
 import XCTest
+
+@testable import MiniDOM
 
 class ParserErrorTests: XCTestCase {
     func testInvalidProcessingInstruction() {
@@ -76,5 +77,16 @@ class ParserErrorTests: XCTestCase {
         expect(result.isFailure).to(beTrue())
         expect(result.value).to(beNil())
         expect(result.error) === error
+    }
+
+    func testInvalidCDATABlock() {
+        let bytes: [UInt8] = [192]
+        let invalidUTF8data = Data(bytes: bytes)
+
+        let nodeStack = NodeStack()
+        let parser = XMLParser(data: "".data(using: .utf8)!)
+
+        // single step or watch log to ensure this is caught
+        nodeStack.parser(parser, foundCDATA: invalidUTF8data)
     }
 }

--- a/Tests/MiniDOMTests/ParserNamespaceTests.swift
+++ b/Tests/MiniDOMTests/ParserNamespaceTests.swift
@@ -1,0 +1,91 @@
+//
+//  ParserNamespaceTests.swift
+//  MiniDOM
+//
+//  Created by Paul Calnan on 3/26/17.
+//  Copyright © 2017 Anodized Software, Inc. All rights reserved.
+//
+
+import Foundation
+import MiniDOM
+import Nimble
+import XCTest
+
+class ParserNamespaceTests: XCTestCase {
+
+    var source: String!
+
+    override func setUp() {
+        super.setUp()
+
+        source = [
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+            "<?xml-stylesheet type='text/css' href='cvslog.css'?>",
+            "<!DOCTYPE cvslog SYSTEM \"cvslog.dtd\">",
+            "<cvslog xmlns=\"http://xml.apple.com/cvslog\">",
+            "  <radar:radar xmlns:radar=\"http://xml.apple.com/radar\">",
+            "    <radar:bugID>2920186</radar:bugID>",
+            "    <radar:title>API/NSXMLParser: there ought to be an NSXMLParser</radar:title>",
+            "  </radar:radar>",
+            "</cvslog>"
+        ].joined(separator: "\n")
+    }
+
+    func testParseWithoutNamespacesOrEntities() {
+        let parser = Parser(string: source)
+
+        let result = parser?.parse()
+        expect(result?.isSuccess).to(beTrue())
+
+        let document = result?.value
+
+        let cvslog = document?.documentElement
+        expect(cvslog).notTo(beNil())
+        expect(cvslog?.tagName) == "cvslog"
+        expect(cvslog?.attributes) == ["xmlns": "http://xml.apple.com/cvslog"]
+        expect(cvslog?.children.count) == 1
+
+        let radar = cvslog?.firstChild
+        expect(radar).notTo(beNil())
+        expect(radar?.nodeName) == "radar:radar"
+        expect(radar?.attributes) == ["xmlns:radar": "http://xml.apple.com/radar"]
+        expect(radar?.children.count) == 2
+
+        let bugID = radar?.firstChild
+        expect(bugID).notTo(beNil())
+        expect(bugID?.nodeName) == "radar:bugID"
+        expect(bugID?.children.count) == 1
+
+        let bugIdText = bugID?.firstChild
+        expect(bugIdText).notTo(beNil())
+        expect(bugIdText?.nodeType) == .text
+        expect(bugIdText?.nodeValue) == "2920186"
+
+        let title = radar?.lastChild
+        expect(title).notTo(beNil())
+        expect(title?.nodeName) == "radar:title"
+        expect(title?.children.count) == 1
+
+        let titleText = title?.firstChild
+        expect(titleText).notTo(beNil())
+        expect(titleText?.nodeType) == .text
+        expect(titleText?.nodeValue) == "API/NSXMLParser: there ought to be an NSXMLParser"
+
+        let formatted = document?.format(indentWith: "  ")
+        expect(formatted) == [
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>",
+            "<?xml-stylesheet type='text/css' href='cvslog.css'?>",
+            // The <!DOCTYPE> entity will be dropped as it is not handled
+            "<cvslog xmlns=\"http://xml.apple.com/cvslog\">",
+            "  <radar:radar xmlns:radar=\"http://xml.apple.com/radar\">",
+            "    <radar:bugID>",
+            "      2920186", // the formatter puts text nodes on a new line
+            "    </radar:bugID>",
+            "    <radar:title>",
+            "      API/NSXMLParser: there ought to be an NSXMLParser",
+            "    </radar:title>",
+            "  </radar:radar>",
+            "</cvslog>"
+        ].joined(separator: "\n")
+    }
+}


### PR DESCRIPTION
Remove namespace support
Using a mock `XMLParser` object, verify that `abortParsing` is called for certain error conditions
Add better empty-stack error detection