### PR TITLE
Swift 3.1 Update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: swift
-osx_image: xcode8.2
+osx_image: xcode8.3
 xcode_workspace: MiniDOM.xcworkspace
 xcode_scheme: MiniDOM
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ osx_image: xcode8.3
 xcode_workspace: MiniDOM.xcworkspace
 xcode_scheme: MiniDOM
 script:
-  - xcodebuild -workspace MiniDOM.xcworkspace -scheme MiniDOM build test -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPad Air 2,OS=10.2'
+  - xcodebuild -workspace MiniDOM.xcworkspace -scheme MiniDOM build test -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPad Air 2,OS=10.3'
 after_success:
   - bash <(curl -s https://codecov.io/bash) -J 'MiniDOM'

--- a/MiniDOM.xcodeproj/project.pbxproj
+++ b/MiniDOM.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		C5EB9CEE1E7CF12D00198F5F /* ParserResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5EB9CED1E7CF12D00198F5F /* ParserResultTests.swift */; };
 		C5EB9CF01E7CF46800198F5F /* ParserErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5EB9CEF1E7CF46800198F5F /* ParserErrorTests.swift */; };
 		C5EB9CF21E7CF5B900198F5F /* VisitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5EB9CF11E7CF5B900198F5F /* VisitorTests.swift */; };
+		C5FCA02D1E8A031400774FF1 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5FCA02C1E8A031400774FF1 /* Result.swift */; };
 		DF76322F08E91CF898242959 /* Pods_MiniDOM.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1C512F3574C721AA341F6A2 /* Pods_MiniDOM.framework */; };
 /* End PBXBuildFile section */
 
@@ -88,6 +89,7 @@
 		C5EB9CED1E7CF12D00198F5F /* ParserResultTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParserResultTests.swift; sourceTree = "<group>"; };
 		C5EB9CEF1E7CF46800198F5F /* ParserErrorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParserErrorTests.swift; sourceTree = "<group>"; };
 		C5EB9CF11E7CF5B900198F5F /* VisitorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VisitorTests.swift; sourceTree = "<group>"; };
+		C5FCA02C1E8A031400774FF1 /* Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
 		E2C07698CC069903105E29D7 /* Pods-MiniDOM.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MiniDOM.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MiniDOM/Pods-MiniDOM.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -155,6 +157,7 @@
 				C5EA38511E78E29E0000D01B /* NodeList.swift */,
 				C54FA8E81E763CE6009EEA73 /* Parser.swift */,
 				C5D2BD031E7793E3001FF7E8 /* Path.swift */,
+				C5FCA02C1E8A031400774FF1 /* Result.swift */,
 				C5202D311E76548400C2B35C /* Search.swift */,
 				C5D2BCF91E77562D001FF7E8 /* String+Whitespace.swift */,
 				C5202D2A1E76460800C2B35C /* Visitor.swift */,
@@ -415,6 +418,7 @@
 				C5EA38521E78E29E0000D01B /* NodeList.swift in Sources */,
 				C5202D321E76548400C2B35C /* Search.swift in Sources */,
 				C5D2BCFA1E77562D001FF7E8 /* String+Whitespace.swift in Sources */,
+				C5FCA02D1E8A031400774FF1 /* Result.swift in Sources */,
 				C5202D2D1E7647D200C2B35C /* Formatter.swift in Sources */,
 				C54FA8EB1E763CE6009EEA73 /* MiniDOM.swift in Sources */,
 				C5C88DD21E7C28C700CEDDA8 /* Log.swift in Sources */,

--- a/Sources/MiniDOM.swift
+++ b/Sources/MiniDOM.swift
@@ -154,7 +154,7 @@ public extension Node {
      - returns: The nodes in the `children` array of the specified type
      */
     public final func children<T: Node>(ofType type: T.Type) -> [T] {
-        return only(nodes: children, ofType: type)
+        return children.only(ofType: T.self)
     }
 
     /// A Boolean value indicating whether the `children` array is not empty.
@@ -271,7 +271,7 @@ public final class Document: ParentNode {
      that is the root element of the document.
      */
     public var documentElement: Element? {
-        return first(in: children, ofType: Element.self)
+        return children.first(ofType: Element.self)
     }
 
     /**

--- a/Sources/NodeList.swift
+++ b/Sources/NodeList.swift
@@ -19,28 +19,27 @@
 
 import Foundation
 
-/**
- Returns only the nodes of the specified type in the specified array.
- 
- - parameter nodes: An array of `Node` objects to filter.
- 
- - parameter type: The target type.
- 
- - returns: All members of the specified array that are of the specified type.
- */
-public func only<T: Node>(nodes: [Node], ofType type: T.Type) -> [T] {
-    return nodes.flatMap({ $0 as? T })
-}
+public extension Array where Element == Node {
 
-/**
- Returns the first node of the specified type in the specified array.
- 
- - parameter nodes: An array of `Node` objects to search.
- 
- - parameter type: The target type.
- 
- - returns: The first node of the specified type.
- */
-public func first<T: Node>(in nodes: [Node], ofType type: T.Type) -> T? {
-    return nodes.first(where: { $0.nodeType == type.nodeType }) as? T
+    /**
+     Returns only the nodes of the specified type.
+
+     - parameter type: The target type.
+
+     - returns: All members of the receiver that are of the specified type.
+     */
+    public func only<T: Node>(ofType type: T.Type) -> [T] {
+        return self.flatMap { $0 as? T }
+    }
+
+    /**
+     Returns the first node of the specified type.
+
+     - parameter type: The target type.
+
+     - returns: The first node of the specified type.
+     */
+    public func first<T: Node>(ofType type: T.Type) -> T? {
+        return first(where: { $0.nodeType == type.nodeType }) as? T
+    }
 }

--- a/Sources/Parser.swift
+++ b/Sources/Parser.swift
@@ -20,62 +20,6 @@
 import Foundation
 
 /**
- Used to represent whether the parsing operation was successful or encountered 
- an error.
- */
-public enum Result<SuccessType> {
-    /**
-     Indicates the parsing operation was successful and resulted in the
-     provided associated value.
-     */
-    case success(SuccessType)
-
-    /**
-     Indicates the parsing operation failed and resulted in the provided
-     associated error value.
-     */
-    case failure(Error)
-
-    /// Returns `true` if the result is a success, `false` otherwise.
-    public var isSuccess: Bool {
-        switch self {
-        case .success:
-            return true
-        case .failure:
-            return false
-        }
-    }
-
-    /// Returns `true` if the result is a failure, `false` otherwise.
-    public var isFailure: Bool {
-        return !isSuccess
-    }
-
-    /**
-     Returns the assoicated value if the result is a success, `nil` otherwise.
-     */
-    public var value: SuccessType? {
-        if case let .success(value) = self {
-            return value
-        }
-
-        return nil
-    }
-
-    /**
-     Returns the associated error value if the result is a failure, `nil` 
-     otherwise.
-     */
-    public var error: Error? {
-        if case let .failure(error) = self {
-            return error
-        }
-
-        return nil
-    }
-}
-
-/**
  Instances of this class parse XML documents into a tree of DOM objects.
  */
 public class Parser {
@@ -164,12 +108,14 @@ public class Parser {
         self.parser = parser
     }
 
+    public typealias ParserResult = Result<Document>
+
     /**
      Performs the parsing operation.
      
      - returns: The result of the parsing operation.
      */
-    public func parse() -> Result<Document> {
+    public func parse() -> ParserResult {
         let stack = NodeStack()
         parser.delegate = stack
 

--- a/Sources/Parser.swift
+++ b/Sources/Parser.swift
@@ -244,7 +244,7 @@ class NodeStack: NSObject, XMLParserDelegate {
     }
 
     func parser(_ parser: XMLParser, foundProcessingInstructionWithTarget target: String, data: String?) {
-        log.debug("target=\(target) data=\(data)")
+        log.debug("target=\(target) data=\(String(describing: data))")
         let pi = ProcessingInstruction(target: target, data: data)
         appendToTopOfStack(child: pi, parser: parser)
     }

--- a/Sources/Result.swift
+++ b/Sources/Result.swift
@@ -1,0 +1,75 @@
+//
+//  Result.swift
+//  MiniDOM
+//
+//  Copyright 2017 Anodized Software, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/**
+ Used to represent whether an operation was successful or encountered an error.
+ */
+public enum Result<SuccessType> {
+    /**
+     Indicates the operation was successful and resulted in the provided
+     associated value.
+     */
+    case success(SuccessType)
+
+    /**
+     Indicates the parsing operation failed and resulted in the provided
+     associated error value.
+     */
+    case failure(Error)
+
+    /// Returns `true` if the result is a success, `false` otherwise.
+    public var isSuccess: Bool {
+        switch self {
+        case .success:
+            return true
+        case .failure:
+            return false
+        }
+    }
+
+    /// Returns `true` if the result is a failure, `false` otherwise.
+    public var isFailure: Bool {
+        return !isSuccess
+    }
+
+    /**
+     Returns the assoicated value if the result is a success, `nil` otherwise.
+     */
+    public var value: SuccessType? {
+        if case let .success(value) = self {
+            return value
+        }
+
+        return nil
+    }
+
+    /**
+     Returns the associated error value if the result is a failure, `nil`
+     otherwise.
+     */
+    public var error: Error? {
+        if case let .failure(error) = self {
+            return error
+        }
+        
+        return nil
+    }
+}

--- a/Tests/MiniDOMTests/TestData/ContentsTests.swift
+++ b/Tests/MiniDOMTests/TestData/ContentsTests.swift
@@ -80,7 +80,7 @@ class ContentsTests: XCTestCase {
 
         let headingTextValues = chapterNodes.flatMap { (chapterNode) -> String? in
             let textNodes = chapterNode.evaluate(path: ["JavaXML:Heading", "#text"])
-            return first(in: textNodes, ofType: Text.self)?.text
+            return textNodes.first(ofType: Text.self)?.text
         }
         expect(headingTextValues.count) == 4
 


### PR DESCRIPTION
Fix compiler warnings.
Utilize new concrete constrained extensions for NodeList functionality.
Move Result to its own file (not really Swift 3.1, just reorganizing)