### PR TITLE
Text-node normalization

### DIFF
--- a/MiniDOM.xcodeproj/project.pbxproj
+++ b/MiniDOM.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		C5C88DDB1E7C89BD00CEDDA8 /* ParserPlistTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5C88DDA1E7C89BD00CEDDA8 /* ParserPlistTests.swift */; };
 		C5D2BCFA1E77562D001FF7E8 /* String+Whitespace.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5D2BCF91E77562D001FF7E8 /* String+Whitespace.swift */; };
 		C5D2BD051E779465001FF7E8 /* Path.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5D2BD031E7793E3001FF7E8 /* Path.swift */; };
+		C5E9AF771E8DF7B300DEDD15 /* TextNodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5E9AF761E8DF7B300DEDD15 /* TextNodeTests.swift */; };
+		C5E9AF791E8DFE8C00DEDD15 /* NormalizeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5E9AF781E8DFE8C00DEDD15 /* NormalizeTests.swift */; };
 		C5EA38521E78E29E0000D01B /* NodeList.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5EA38511E78E29E0000D01B /* NodeList.swift */; };
 		C5EB9CE41E7CC85700198F5F /* PathSimpleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5EB9CE31E7CC85700198F5F /* PathSimpleTests.swift */; };
 		C5EB9CE61E7CC94600198F5F /* StringWhitespaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5EB9CE51E7CC94600198F5F /* StringWhitespaceTests.swift */; };
@@ -73,6 +75,8 @@
 		C5D2BCF91E77562D001FF7E8 /* String+Whitespace.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Whitespace.swift"; sourceTree = "<group>"; };
 		C5D2BCFD1E775BAB001FF7E8 /* RSSTestsSource.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = RSSTestsSource.xml; sourceTree = "<group>"; };
 		C5D2BD031E7793E3001FF7E8 /* Path.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Path.swift; sourceTree = "<group>"; };
+		C5E9AF761E8DF7B300DEDD15 /* TextNodeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextNodeTests.swift; sourceTree = "<group>"; };
+		C5E9AF781E8DFE8C00DEDD15 /* NormalizeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NormalizeTests.swift; sourceTree = "<group>"; };
 		C5EA38511E78E29E0000D01B /* NodeList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NodeList.swift; sourceTree = "<group>"; };
 		C5EB9CE31E7CC85700198F5F /* PathSimpleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PathSimpleTests.swift; sourceTree = "<group>"; };
 		C5EB9CE51E7CC94600198F5F /* StringWhitespaceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringWhitespaceTests.swift; sourceTree = "<group>"; };
@@ -156,6 +160,7 @@
 				C5C88DD31E7C861E00CEDDA8 /* FormatterTests.swift */,
 				C54FA8EF1E763CEE009EEA73 /* Info.plist */,
 				C5EB9CEB1E7CEE0B00198F5F /* LogTests.swift */,
+				C5E9AF781E8DFE8C00DEDD15 /* NormalizeTests.swift */,
 				C532F9B91E82128E00FEAD1A /* ParserCreationTests.swift */,
 				C5EB9CEF1E7CF46800198F5F /* ParserErrorTests.swift */,
 				C56856E91E88BDF40058EF81 /* ParserNamespaceTests.swift */,
@@ -165,6 +170,7 @@
 				C5EB9CE31E7CC85700198F5F /* PathSimpleTests.swift */,
 				C5EB9CE51E7CC94600198F5F /* StringWhitespaceTests.swift */,
 				C5D2BCF01E773C26001FF7E8 /* TestData */,
+				C5E9AF761E8DF7B300DEDD15 /* TextNodeTests.swift */,
 				C5EB9CF11E7CF5B900198F5F /* VisitorTests.swift */,
 				C5C88DD51E7C867900CEDDA8 /* XCTestCase+ParseUtil.swift */,
 			);
@@ -325,6 +331,8 @@
 				C532F9C01E82333900FEAD1A /* ContentsTestsSource.swift in Sources */,
 				C5C88DDB1E7C89BD00CEDDA8 /* ParserPlistTests.swift in Sources */,
 				C5EB9CE61E7CC94600198F5F /* StringWhitespaceTests.swift in Sources */,
+				C5E9AF791E8DFE8C00DEDD15 /* NormalizeTests.swift in Sources */,
+				C5E9AF771E8DF7B300DEDD15 /* TextNodeTests.swift in Sources */,
 				C532F9BD1E82325900FEAD1A /* RSSTestsSource.swift in Sources */,
 				C5C88DD41E7C861E00CEDDA8 /* FormatterTests.swift in Sources */,
 				C5C88DD71E7C869500CEDDA8 /* XCTestCase+ParseUtil.swift in Sources */,

--- a/MiniDOM.xcodeproj/project.pbxproj
+++ b/MiniDOM.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		C54FA8EB1E763CE6009EEA73 /* MiniDOM.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54FA8E71E763CE6009EEA73 /* MiniDOM.swift */; };
 		C54FA8EC1E763CE6009EEA73 /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54FA8E81E763CE6009EEA73 /* Parser.swift */; };
 		C56856EA1E88BDF40058EF81 /* ParserNamespaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C56856E91E88BDF40058EF81 /* ParserNamespaceTests.swift */; };
+		C5796E9F1E8EE3C500FEEBC9 /* NodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5796E9E1E8EE3C500FEEBC9 /* NodeTests.swift */; };
 		C5C88DD21E7C28C700CEDDA8 /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5C88DD11E7C28C700CEDDA8 /* Log.swift */; };
 		C5C88DD41E7C861E00CEDDA8 /* FormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5C88DD31E7C861E00CEDDA8 /* FormatterTests.swift */; };
 		C5C88DD71E7C869500CEDDA8 /* XCTestCase+ParseUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5C88DD51E7C867900CEDDA8 /* XCTestCase+ParseUtil.swift */; };
@@ -65,6 +66,7 @@
 		C54FA8EF1E763CEE009EEA73 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C54FA8F41E763D42009EEA73 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		C56856E91E88BDF40058EF81 /* ParserNamespaceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParserNamespaceTests.swift; sourceTree = "<group>"; };
+		C5796E9E1E8EE3C500FEEBC9 /* NodeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NodeTests.swift; sourceTree = "<group>"; };
 		C5C88DD11E7C28C700CEDDA8 /* Log.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Log.swift; sourceTree = "<group>"; };
 		C5C88DD31E7C861E00CEDDA8 /* FormatterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormatterTests.swift; sourceTree = "<group>"; };
 		C5C88DD51E7C867900CEDDA8 /* XCTestCase+ParseUtil.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+ParseUtil.swift"; sourceTree = "<group>"; };
@@ -160,6 +162,7 @@
 				C5C88DD31E7C861E00CEDDA8 /* FormatterTests.swift */,
 				C54FA8EF1E763CEE009EEA73 /* Info.plist */,
 				C5EB9CEB1E7CEE0B00198F5F /* LogTests.swift */,
+				C5796E9E1E8EE3C500FEEBC9 /* NodeTests.swift */,
 				C5E9AF781E8DFE8C00DEDD15 /* NormalizeTests.swift */,
 				C532F9B91E82128E00FEAD1A /* ParserCreationTests.swift */,
 				C5EB9CEF1E7CF46800198F5F /* ParserErrorTests.swift */,
@@ -322,6 +325,7 @@
 			files = (
 				C5EB9CF21E7CF5B900198F5F /* VisitorTests.swift in Sources */,
 				C5EB9CF01E7CF46800198F5F /* ParserErrorTests.swift in Sources */,
+				C5796E9F1E8EE3C500FEEBC9 /* NodeTests.swift in Sources */,
 				C56856EA1E88BDF40058EF81 /* ParserNamespaceTests.swift in Sources */,
 				C5C88DD91E7C889200CEDDA8 /* ParserSimpleTests.swift in Sources */,
 				C5EB9CEE1E7CF12D00198F5F /* ParserResultTests.swift in Sources */,

--- a/Sources/Formatter.swift
+++ b/Sources/Formatter.swift
@@ -19,7 +19,70 @@
 
 import Foundation
 
-class Formatter: Visitor {
+class Formatter {
+    var xmlPrologue: String {
+        return "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+    }
+
+    func formatStart(_ element: Element) -> String {
+        let isLeaf = !element.hasChildren
+        let slashIfLeaf = isLeaf ? "/" : ""
+
+        if let attrs = formatAttributes(of: element) {
+            return "<\(element.tagName) \(attrs)\(slashIfLeaf)>"
+        }
+        else {
+            return "<\(element.tagName)\(slashIfLeaf)>"
+        }
+    }
+
+    func formatEnd(_ element: Element) -> String? {
+        if element.hasChildren {
+            return "</\(element.tagName)>"
+        }
+
+        return nil
+    }
+
+    func formatAttributes(of element: Element) -> String? {
+        guard let attrs = element.attributes, !attrs.isEmpty else {
+            return nil
+        }
+
+        var formatted: [String] = []
+        let sortedAttributes = attrs.sorted { (kv1: (String, String), kv2: (String, String)) -> Bool in
+            return kv1.0 < kv2.0
+        }
+
+        for (key, value) in sortedAttributes {
+            formatted.append("\(key)=\"\(value)\"")
+        }
+
+        return formatted.joined(separator: " ")
+    }
+
+    func format(_ processingInstruction: ProcessingInstruction) -> String {
+        var parts: [String] = []
+
+        parts.append(processingInstruction.target)
+        if let data = processingInstruction.data {
+            parts.append(data)
+        }
+
+        let body = parts.joined(separator: " ")
+        return "<?\(body)?>"
+    }
+
+    func format(_ comment: Comment) -> String {
+        return "<!--\(comment.text)-->"
+    }
+
+    func format(_ cdataSection: CDATASection) -> String {
+        return "<![CDATA[\(cdataSection.text)]]>"
+    }
+}
+
+class PrettyPrinter: Formatter, Visitor {
     private struct Line {
         let depth: Int
         let value: String
@@ -37,7 +100,7 @@ class Formatter: Visitor {
 
     private var lines: [Line] = []
 
-    private(set) public var formattedString: String?
+    private(set) var formattedString: String?
 
     private let indentString: String
 
@@ -45,79 +108,91 @@ class Formatter: Visitor {
         self.indentString = string
     }
 
-    private func addLine(_ string: String) {
+    private func addLine(_ string: String?) {
+        guard let string = string else {
+            return
+        }
+
         lines.append(Line(depth: depth, value: string))
     }
 
     public func beginVisit(_ document: Document) {
-        addLine("<?xml version=\"1.0\" encoding=\"utf-8\"?>")
+        addLine(xmlPrologue)
     }
 
     public func endVisit(_ document: Document) {
         formattedString = lines.map({ $0.format(indentingWith: indentString) }).joined(separator: "\n")
     }
 
-
     public func beginVisit(_ element: Element) {
-        let isLeaf = !element.hasChildren
-        let slashIfLeaf = isLeaf ? "/" : ""
-
-        if let attrs = formatAttributes(of: element) {
-            addLine("<\(element.tagName) \(attrs)\(slashIfLeaf)>")
-        }
-        else {
-            addLine("<\(element.tagName)\(slashIfLeaf)>")
-        }
+        addLine(formatStart(element))
         depth += 1
     }
 
     public func endVisit(_ element: Element) {
         depth -= 1
-
-        if element.hasChildren {
-            addLine("</\(element.tagName)>")
-        }
-    }
-
-    private func formatAttributes(of element: Element) -> String? {
-        guard let attrs = element.attributes, !attrs.isEmpty else {
-            return nil
-        }
-
-        var formatted: [String] = []
-        let sortedAttributes = attrs.sorted { (kv1: (String, String), kv2: (String, String)) -> Bool in
-            return kv1.0 < kv2.0
-        }
-
-        for (key, value) in sortedAttributes {
-            formatted.append("\(key)=\"\(value)\"")
-        }
-
-        return formatted.joined(separator: " ")
+        addLine(formatEnd(element))
     }
 
     public func visit(_ text: Text) {
-        addLine(text.text)
+        let trimmed = text.text.trimmed()
+        if trimmed.isEmpty {
+            return
+        }
+
+        addLine(trimmed)
     }
 
     public func visit(_ processingInstruction: ProcessingInstruction) {
-        var parts: [String] = []
-
-        parts.append(processingInstruction.target)
-        if let data = processingInstruction.data {
-            parts.append(data)
-        }
-
-        let body = parts.joined(separator: " ")
-        addLine("<?\(body)?>")
+        addLine(format(processingInstruction))
     }
 
     public func visit(_ comment: Comment) {
-        addLine("<!--\(comment.text)-->")
+        addLine(format(comment))
     }
 
     public func visit(_ cdataSection: CDATASection) {
-        addLine("<![CDATA[\(cdataSection.text)]]>")
+        addLine(format(cdataSection))
+    }
+}
+
+class TreeDumper: Formatter, Visitor {
+    private var parts: [String] = []
+
+    private(set) var formattedString: String?
+
+    public func beginVisit(_ document: Document) {
+        parts.append(xmlPrologue)
+    }
+
+    public func endVisit(_ document: Document) {
+        formattedString = parts.joined()
+    }
+
+    public func beginVisit(_ element: Element) {
+        parts.append(formatStart(element))
+    }
+
+    public func endVisit(_ element: Element) {
+        if let part = formatEnd(element) {
+            parts.append(part)
+        }
+    }
+
+    public func visit(_ text: Text) {
+        parts.append(text.text)
+    }
+
+    public func visit(_ processingInstruction: ProcessingInstruction) {
+        parts.append(format(processingInstruction))
+    }
+
+    public func visit(_ comment: Comment) {
+        parts.append(format(comment))
+    }
+
+    public func visit(_ cdataSection: CDATASection) {
+        parts.append(format(cdataSection))
     }
 }
 
@@ -130,8 +205,14 @@ public extension Node {
      - returns: A formatted XML string representation of this node and its 
      descendants.
      */
-    public func format(indentWith: String = "\t") -> String? {
-        let formatter = Formatter(indentWith: indentWith)
+    public func prettyPrint(indentWith: String = "\t") -> String? {
+        let formatter = PrettyPrinter(indentWith: indentWith)
+        accept(formatter)
+        return formatter.formattedString
+    }
+
+    public func dump() -> String? {
+        let formatter = TreeDumper()
         accept(formatter)
         return formatter.formattedString
     }

--- a/Sources/Formatter.swift
+++ b/Sources/Formatter.swift
@@ -31,9 +31,8 @@ class Formatter {
         if let attrs = formatAttributes(of: element) {
             return "<\(element.tagName) \(attrs)\(slashIfLeaf)>"
         }
-        else {
-            return "<\(element.tagName)\(slashIfLeaf)>"
-        }
+
+        return "<\(element.tagName)\(slashIfLeaf)>"
     }
 
     func formatEnd(_ element: Element) -> String? {
@@ -163,6 +162,7 @@ class TreeDumper: Formatter, Visitor {
 
     public func beginVisit(_ document: Document) {
         parts.append(xmlPrologue)
+        parts.append("\n")
     }
 
     public func endVisit(_ document: Document) {
@@ -198,7 +198,8 @@ class TreeDumper: Formatter, Visitor {
 
 public extension Node {
     /**
-     Generates an XML string representation of this node and its descendants.
+     Generates a formatted XML string representation of this node and its 
+     descendants.
      
      - parameter indentWith: The string used to indent the formatted string.
      
@@ -211,6 +212,13 @@ public extension Node {
         return formatter.formattedString
     }
 
+    /**
+     Generates an unformatted XML string representation of this node and its 
+     descendants.
+
+     - returns: A formatted XML string representation of this node and its
+     descendants.
+     */
     public func dump() -> String? {
         let formatter = TreeDumper()
         accept(formatter)

--- a/Sources/MiniDOM.swift
+++ b/Sources/MiniDOM.swift
@@ -22,10 +22,11 @@
  Object Model.
 
  This is intended to provided a subset of the behavior described in the
- [DOM Level 1 specification][1]. Much of this file's documentation is adapted
- from that document.
+ [DOM Level 1 specification][1] and the [DOM Level 2 specification][2]. Much of 
+ this file's documentation is adapted from those documents.
 
  [1]: https://www.w3.org/TR/REC-DOM-Level-1/level-one-core.html
+ [2]: https://www.w3.org/TR/DOM-Level-2-Core/core.html
  */
 
 import Foundation
@@ -138,6 +139,14 @@ public protocol Node: Visitable {
      */
     var children: [Node] { get }
 
+    /**
+     Puts all `Text` nodes in the full depth of the sub-tree underneath this 
+     `Node`, into a "normal" form where only structure (e.g., elements, 
+     comments, processing instructions, and CDATA sections) separates `Text` 
+     nodes, i.e., there are neither adjacent `Text` nodes nor empty `Text` 
+     nodes. This can be used to ensure that the DOM view of a document is the 
+     same as if it were saved and re-loaded.
+     */
     mutating func normalize()
 }
 
@@ -174,18 +183,22 @@ public extension Node {
         return children.last
     }
 
+    /// Returns the `Element` objects from the `children` array.
     public final var childElements: [Element] {
         return self.children(ofType: Element.self)
     }
 
+    /// A Boolean value indicating whether the `childElements` array is not empty
     public final var hasChildElements: Bool {
         return !childElements.isEmpty
     }
 
+    /// The first element in the `childElements` array.
     public final var firstChildElement: Element? {
         return childElements.first
     }
 
+    /// The last element in the `childElements` array.
     public final var lastChildElement: Element? {
         return childElements.last
     }

--- a/Sources/Parser.swift
+++ b/Sources/Parser.swift
@@ -115,7 +115,7 @@ public class Parser {
      
      - returns: The result of the parsing operation.
      */
-    public func parse() -> ParserResult {
+    public final func parse() -> ParserResult {
         let stack = NodeStack()
         parser.delegate = stack
 
@@ -179,13 +179,7 @@ class NodeStack: NSObject, XMLParserDelegate {
     }
 
     func parser(_ parser: XMLParser, foundCharacters string: String) {
-        let trimmed = string.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
-        guard !trimmed.isEmpty else {
-            return
-        }
-
-        log.debug("string=\(trimmed)")
-        let text = Text(text: trimmed)
+        let text = Text(text: string)
         appendToTopOfStack(child: text, parser: parser)
     }
 

--- a/Sources/Path.swift
+++ b/Sources/Path.swift
@@ -113,7 +113,7 @@ public extension Node {
      to this node.
      */
 
-    func evaluate(path: [String]) -> [Node] {
+    public final func evaluate(path: [String]) -> [Node] {
         let visitor = PathSearch(path: path)
 
         // Start with the children - exclude the current node in the search.

--- a/Sources/Search.swift
+++ b/Sources/Search.swift
@@ -44,7 +44,7 @@ public extension Document {
 
      - returns: An array of elements with the specified tag name.
      */
-    public func elements(withTagName name: String) -> [Element] {
+    public final func elements(withTagName name: String) -> [Element] {
         return elements(where: { $0.tagName == name })
     }
 
@@ -58,7 +58,7 @@ public extension Document {
 
      - returns: An array of the elements that `predicate` allowed.
      */
-    public func elements(where predicate: @escaping (Element) -> Bool) -> [Element] {
+    public final func elements(where predicate: @escaping (Element) -> Bool) -> [Element] {
         let visitor = ElementSearch(predicate: predicate)
         documentElement?.accept(visitor)
         return visitor.elements

--- a/Tests/MiniDOMTests/FormatterTests.swift
+++ b/Tests/MiniDOMTests/FormatterTests.swift
@@ -24,12 +24,29 @@ import XCTest
 class FormatterTests: XCTestCase {
     var source: String!
 
+    var expectedPrettyPrinted: String!
+
     var document: Document!
     
     override func setUp() {
         super.setUp()
 
         source = [
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>",
+            "<foo>",
+            "  <!-- This is a comment -->",
+            "  <bar attr1=\"value1\" attr2=\"value2\"/>",
+            "  <?target attr=\"value\"?>",
+            "  <![CDATA[<div>This is some HTML</div>]]>",
+            "  <baz>",
+            "    <fnord>This is some text</fnord>",
+            "    <fnord>This is some more text</fnord>",
+            "  </baz>",
+            "  <qux/>",
+            "</foo>"
+        ].joined(separator: "\n")
+
+        expectedPrettyPrinted = [
             "<?xml version=\"1.0\" encoding=\"utf-8\"?>",
             "<foo>",
             "  <!-- This is a comment -->",
@@ -44,6 +61,7 @@ class FormatterTests: XCTestCase {
             "      This is some more text",
             "    </fnord>",
             "  </baz>",
+            "  <qux/>",
             "</foo>"
         ].joined(separator: "\n")
 
@@ -53,7 +71,12 @@ class FormatterTests: XCTestCase {
     func testReproduceSourceString() {
         let formatted = document.prettyPrint(indentWith: "  ")
         XCTAssertNotNil(formatted)
-        print(formatted ?? "nil")
+        XCTAssertEqual(formatted, expectedPrettyPrinted)
+    }
+
+    func testDumper() {
+        let formatted = document.dump()
+        XCTAssertNotNil(formatted)
         XCTAssertEqual(formatted, source)
     }
     

--- a/Tests/MiniDOMTests/FormatterTests.swift
+++ b/Tests/MiniDOMTests/FormatterTests.swift
@@ -51,8 +51,9 @@ class FormatterTests: XCTestCase {
     }
 
     func testReproduceSourceString() {
-        let formatted = document.format(indentWith: "  ")
+        let formatted = document.prettyPrint(indentWith: "  ")
         XCTAssertNotNil(formatted)
+        print(formatted ?? "nil")
         XCTAssertEqual(formatted, source)
     }
     

--- a/Tests/MiniDOMTests/NodeTests.swift
+++ b/Tests/MiniDOMTests/NodeTests.swift
@@ -1,0 +1,34 @@
+//
+//  NodeTests.swift
+//  MiniDOM
+//
+//  Created by Paul Calnan on 3/31/17.
+//  Copyright © 2017 Anodized Software, Inc. All rights reserved.
+//
+
+import Foundation
+import MiniDOM
+import XCTest
+
+class NodeTests: XCTestCase {
+    
+    func testNormalizeLeafNode() {
+        var text = Text(text: "Testing 1 2 3")
+        text.normalize()
+        XCTAssertEqual(text.text, "Testing 1 2 3")
+    }
+
+    func testHasChildElements() {
+        let element = Element(tagName: "foo")
+        XCTAssertFalse(element.hasChildren)
+        XCTAssertFalse(element.hasChildElements)
+
+        element.children.append(Text(text: "testing"))
+        XCTAssertTrue(element.hasChildren)
+        XCTAssertFalse(element.hasChildElements)
+
+        element.children.append(Element(tagName: "bar"))
+        XCTAssertTrue(element.hasChildren)
+        XCTAssertTrue(element.hasChildElements)
+    }
+}

--- a/Tests/MiniDOMTests/NormalizeTests.swift
+++ b/Tests/MiniDOMTests/NormalizeTests.swift
@@ -1,0 +1,65 @@
+//
+//  NormalizeTests.swift
+//  MiniDOM
+//
+//  Created by Paul Calnan on 3/30/17.
+//  Copyright © 2017 Anodized Software, Inc. All rights reserved.
+//
+
+import MiniDOM
+import XCTest
+
+class NormalizeTests: XCTestCase {
+
+    func testNormalizeTextNodesOnly() {
+        var element = Element(tagName: "element", children: [
+            Text(text: "this is "),
+            Text(text: "a test"),
+            Text(text: " of the normalization algorithm")
+        ])
+
+        element.normalize()
+        XCTAssertEqual(element.nodeName, "element")
+        XCTAssertEqual(element.children.count, 1)
+        XCTAssertEqual(element.firstChild?.nodeType, .text)
+        XCTAssertEqual(element.firstChild?.nodeValue, "this is a test of the normalization algorithm")
+    }
+
+    func testNormalizeMixed() {
+        var element = Element(tagName: "element", children: [
+            Text(text: "this is "),
+            Text(text: "a test"),
+            Element(tagName: "child"),
+            Text(text: "of the normalization algorithm")
+        ])
+
+        element.normalize()
+        XCTAssertEqual(element.nodeName, "element")
+        XCTAssertEqual(element.children.count, 3)
+        XCTAssertEqual(element.firstChild?.nodeType, .text)
+        XCTAssertEqual(element.firstChild?.nodeValue, "this is a test")
+        XCTAssertEqual(element.lastChild?.nodeType, .text)
+        XCTAssertEqual(element.lastChild?.nodeValue, "of the normalization algorithm")
+    }
+
+    func testNormalizeChildren() {
+        var element = Element(tagName: "element", children: [
+            Text(text: "this is "),
+            Text(text: "a test"),
+            Element(tagName: "child", children: [
+                Text(text: "the child element "),
+                Text(text: "has text, too")
+            ])
+        ])
+
+        element.normalize()
+        XCTAssertEqual(element.nodeName, "element")
+        XCTAssertEqual(element.children.count, 2)
+        XCTAssertEqual(element.firstChild?.nodeType, .text)
+        XCTAssertEqual(element.firstChild?.nodeValue, "this is a test")
+        XCTAssertEqual(element.lastChild?.nodeType, .element)
+        XCTAssertEqual(element.lastChild?.children.count, 1)
+        XCTAssertEqual(element.lastChild?.firstChild?.nodeType, .text)
+        XCTAssertEqual(element.lastChild?.firstChild?.nodeValue, "the child element has text, too")
+    }
+}

--- a/Tests/MiniDOMTests/ParserNamespaceTests.swift
+++ b/Tests/MiniDOMTests/ParserNamespaceTests.swift
@@ -36,21 +36,22 @@ class ParserNamespaceTests: XCTestCase {
         let result = parser?.parse()
         XCTAssertTrue(result?.isSuccess == true)
 
-        let document = result?.value
+        var document = result?.value
+        document?.normalize()
 
         let cvslog = document?.documentElement
         XCTAssertNotNil(cvslog)
         XCTAssertEqual(cvslog?.tagName, "cvslog")
         XCTAssertEqual(cvslog?.attributes ?? [:], ["xmlns": "http://xml.apple.com/cvslog"])
-        XCTAssertEqual(cvslog?.children.count, 1)
+        XCTAssertEqual(cvslog?.childElements.count, 1)
 
-        let radar = cvslog?.firstChild
+        let radar = cvslog?.firstChildElement
         XCTAssertNotNil(radar)
         XCTAssertEqual(radar?.nodeName, "radar:radar")
         XCTAssertEqual(radar?.attributes ?? [:], ["xmlns:radar": "http://xml.apple.com/radar"])
-        XCTAssertEqual(radar?.children.count, 2)
+        XCTAssertEqual(radar?.childElements.count, 2)
 
-        let bugID = radar?.firstChild
+        let bugID = radar?.firstChildElement
         XCTAssertNotNil(bugID)
         XCTAssertEqual(bugID?.nodeName, "radar:bugID")
         XCTAssertEqual(bugID?.children.count, 1)
@@ -60,7 +61,7 @@ class ParserNamespaceTests: XCTestCase {
         XCTAssertEqual(bugIdText?.nodeType, .text)
         XCTAssertEqual(bugIdText?.nodeValue, "2920186")
 
-        let title = radar?.lastChild
+        let title = radar?.lastChildElement
         XCTAssertNotNil(title)
         XCTAssertEqual(title?.nodeName, "radar:title")
         XCTAssertEqual(title?.children.count, 1)
@@ -70,7 +71,8 @@ class ParserNamespaceTests: XCTestCase {
         XCTAssertEqual(titleText?.nodeType, .text)
         XCTAssertEqual(titleText?.nodeValue, "API/NSXMLParser: there ought to be an NSXMLParser")
 
-        let formatted = document?.format(indentWith: "  ")
+        let formatted = document?.prettyPrint(indentWith: "  ")
+        print(formatted ?? "nil")
         XCTAssertEqual(formatted, [
             "<?xml version=\"1.0\" encoding=\"utf-8\"?>",
             "<?xml-stylesheet type='text/css' href='cvslog.css'?>",

--- a/Tests/MiniDOMTests/ParserNamespaceTests.swift
+++ b/Tests/MiniDOMTests/ParserNamespaceTests.swift
@@ -72,7 +72,6 @@ class ParserNamespaceTests: XCTestCase {
         XCTAssertEqual(titleText?.nodeValue, "API/NSXMLParser: there ought to be an NSXMLParser")
 
         let formatted = document?.prettyPrint(indentWith: "  ")
-        print(formatted ?? "nil")
         XCTAssertEqual(formatted, [
             "<?xml version=\"1.0\" encoding=\"utf-8\"?>",
             "<?xml-stylesheet type='text/css' href='cvslog.css'?>",

--- a/Tests/MiniDOMTests/ParserPlistTests.swift
+++ b/Tests/MiniDOMTests/ParserPlistTests.swift
@@ -29,7 +29,7 @@ class ParserPlistTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        let source = [
+        source = [
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
             "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">",
             "<plist version=\"1.0\">",
@@ -70,18 +70,16 @@ class ParserPlistTests: XCTestCase {
     func testSingleDictElementUnderRoot() {
         let documentElement = document.documentElement
 
-        XCTAssertEqual(documentElement?.children.count, 1)
+        XCTAssertEqual(documentElement?.childElements.count, 1)
 
-        let dict = documentElement?.firstChild
+        let dict = documentElement?.firstChildElement
         XCTAssertNotNil(dict)
         XCTAssertEqual(dict?.nodeName, "dict")
-        XCTAssertEqual(dict?.children.count, 16)
+        XCTAssertEqual(dict?.childElements.count, 16)
     }
 
     func testDictElementIsCorrect() {
-        let dict = document.documentElement?.firstChild
-
-        let expectedNodeNames: [String] = [
+        let expectedElementNames: [String] = [
             "key",
             "string",
             "key",
@@ -99,8 +97,10 @@ class ParserPlistTests: XCTestCase {
             "key",
             "string",
         ]
-        let actualNodeNames: [String] = dict?.children.map { $0.nodeName } ?? []
-        XCTAssertEqual(expectedNodeNames, actualNodeNames)
+
+        let dict = document.documentElement?.firstChildElement
+        let actualElementNames: [String] = dict?.childElements.map { $0.nodeName } ?? []
+        XCTAssertEqual(expectedElementNames, actualElementNames)
 
         let expectedNodeValues: [String] = [
             "CFBundleDevelopmentRegion",

--- a/Tests/MiniDOMTests/ParserSimpleTests.swift
+++ b/Tests/MiniDOMTests/ParserSimpleTests.swift
@@ -59,7 +59,7 @@ class ParserSimpleTests: XCTestCase {
     }
 
     func testDocumentElementChildNodes() {
-        let children = document.documentElement?.children
+        let children = document.documentElement?.children.filter({ $0.nodeType != .text })
 
         XCTAssertNotNil(children)
         XCTAssertEqual(children?.isEmpty, false)
@@ -94,10 +94,10 @@ class ParserSimpleTests: XCTestCase {
 
         XCTAssertEqual(fnords[0].children.count, 1)
         XCTAssertEqual(fnords[0].firstChild?.nodeType, .text)
-        XCTAssertEqual(fnords[0].firstChild?.nodeValue, "This is some text")
+        XCTAssertEqual(fnords[0].firstChild?.nodeValue?.trimmed(), "This is some text")
 
         XCTAssertEqual(fnords[1].children.count, 1)
         XCTAssertEqual(fnords[1].firstChild?.nodeType, .text)
-        XCTAssertEqual(fnords[1].firstChild?.nodeValue, "This is some more text")
+        XCTAssertEqual(fnords[1].firstChild?.nodeValue?.trimmed(), "This is some more text")
     }
 }

--- a/Tests/MiniDOMTests/TestData/ContentsTests.swift
+++ b/Tests/MiniDOMTests/TestData/ContentsTests.swift
@@ -27,6 +27,7 @@ class ContentsTests: XCTestCase {
     override func setUp() {
         super.setUp()
         document = loadXML(string: contentsTestsSource)
+        document.normalize()
     }
 
     func testThreeProcessingInstructions() {
@@ -93,11 +94,9 @@ class ContentsTests: XCTestCase {
 
     func testLastChild() {
         let de = document.documentElement
-        let last = de?.lastChild
+        let last = de?.lastChildElement
         XCTAssertNotNil(last)
         XCTAssertEqual(last?.nodeName, "JavaXML:Contents")
-
-        let lastElement = last as? Element
-        XCTAssertEqual(lastElement?.attributes ?? [:], ["xmlns:topic": "http://www.oreilly.com/topics"])
+        XCTAssertEqual(last?.attributes ?? [:], ["xmlns:topic": "http://www.oreilly.com/topics"])
     }
 }

--- a/Tests/MiniDOMTests/TextNodeTests.swift
+++ b/Tests/MiniDOMTests/TextNodeTests.swift
@@ -1,0 +1,46 @@
+//
+//  TextNodeTests.swift
+//  MiniDOM
+//
+//  Created by Paul Calnan on 3/30/17.
+//  Copyright © 2017 Anodized Software, Inc. All rights reserved.
+//
+
+import Foundation
+import MiniDOM
+import XCTest
+
+class TextNodeTests: XCTestCase {
+
+    var source: String!
+
+    var document: Document!
+    
+    override func setUp() {
+        super.setUp()
+
+        source = [
+            "<feed>",
+            "<item>",
+            "<title>California Bill To Ban “Fake News” Would Be Disastrous for Political Speech</title>",
+            "</item>",
+            "<item>",
+            "<title>Small ISPs Oppose Congress&#039;s Move to Abolish Privacy Protections</title>",
+            "</item>",
+            "</feed>"
+        ].joined(separator: "\n")
+
+        document = loadXML(string: source)
+    }
+
+    func testFirstTitle() {
+        let title = document.elements(withTagName: "title").first
+        XCTAssertNotNil(title)
+
+        let titleTextNodes = title?.children(ofType: Text.self)
+        XCTAssertNotNil(titleTextNodes)
+        XCTAssertEqual(titleTextNodes?.count, 2)
+        XCTAssertEqual(titleTextNodes?.flatMap({ $0.nodeValue }) ?? [],
+                       ["California Bill To Ban ", "“Fake News” Would Be Disastrous for Political Speech"])
+    }
+}


### PR DESCRIPTION
- Added text-node normalization algorithm per DOM Level 2 specification.
- Split formatter into a pretty-printer and a dumper (which dumps the nodes without additional formatting).
- Added `childElements`/`firstChildElement`/`lastChildElement` accessors on `Node`.
- Unit tests and documentation.