### PR TITLE
Improved path evaluation

### DIFF
--- a/MiniDOM.xcodeproj/project.pbxproj
+++ b/MiniDOM.xcodeproj/project.pbxproj
@@ -29,7 +29,7 @@
 		C5E9AF771E8DF7B300DEDD15 /* TextNodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5E9AF761E8DF7B300DEDD15 /* TextNodeTests.swift */; };
 		C5E9AF791E8DFE8C00DEDD15 /* NormalizeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5E9AF781E8DFE8C00DEDD15 /* NormalizeTests.swift */; };
 		C5EA38521E78E29E0000D01B /* NodeList.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5EA38511E78E29E0000D01B /* NodeList.swift */; };
-		C5EB9CE41E7CC85700198F5F /* PathSimpleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5EB9CE31E7CC85700198F5F /* PathSimpleTests.swift */; };
+		C5EB9CE41E7CC85700198F5F /* PathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5EB9CE31E7CC85700198F5F /* PathTests.swift */; };
 		C5EB9CE61E7CC94600198F5F /* StringWhitespaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5EB9CE51E7CC94600198F5F /* StringWhitespaceTests.swift */; };
 		C5EB9CE81E7CCA1E00198F5F /* ContentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5EB9CE71E7CCA1E00198F5F /* ContentsTests.swift */; };
 		C5EB9CEA1E7CCB1300198F5F /* RSSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5EB9CE91E7CCB1300198F5F /* RSSTests.swift */; };
@@ -80,7 +80,7 @@
 		C5E9AF761E8DF7B300DEDD15 /* TextNodeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextNodeTests.swift; sourceTree = "<group>"; };
 		C5E9AF781E8DFE8C00DEDD15 /* NormalizeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NormalizeTests.swift; sourceTree = "<group>"; };
 		C5EA38511E78E29E0000D01B /* NodeList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NodeList.swift; sourceTree = "<group>"; };
-		C5EB9CE31E7CC85700198F5F /* PathSimpleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PathSimpleTests.swift; sourceTree = "<group>"; };
+		C5EB9CE31E7CC85700198F5F /* PathTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PathTests.swift; sourceTree = "<group>"; };
 		C5EB9CE51E7CC94600198F5F /* StringWhitespaceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringWhitespaceTests.swift; sourceTree = "<group>"; };
 		C5EB9CE71E7CCA1E00198F5F /* ContentsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentsTests.swift; sourceTree = "<group>"; };
 		C5EB9CE91E7CCB1300198F5F /* RSSTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RSSTests.swift; sourceTree = "<group>"; };
@@ -170,7 +170,7 @@
 				C5C88DDA1E7C89BD00CEDDA8 /* ParserPlistTests.swift */,
 				C5EB9CED1E7CF12D00198F5F /* ParserResultTests.swift */,
 				C5C88DD81E7C889200CEDDA8 /* ParserSimpleTests.swift */,
-				C5EB9CE31E7CC85700198F5F /* PathSimpleTests.swift */,
+				C5EB9CE31E7CC85700198F5F /* PathTests.swift */,
 				C5EB9CE51E7CC94600198F5F /* StringWhitespaceTests.swift */,
 				C5D2BCF01E773C26001FF7E8 /* TestData */,
 				C5E9AF761E8DF7B300DEDD15 /* TextNodeTests.swift */,
@@ -340,7 +340,7 @@
 				C532F9BD1E82325900FEAD1A /* RSSTestsSource.swift in Sources */,
 				C5C88DD41E7C861E00CEDDA8 /* FormatterTests.swift in Sources */,
 				C5C88DD71E7C869500CEDDA8 /* XCTestCase+ParseUtil.swift in Sources */,
-				C5EB9CE41E7CC85700198F5F /* PathSimpleTests.swift in Sources */,
+				C5EB9CE41E7CC85700198F5F /* PathTests.swift in Sources */,
 				C532F9BA1E82128E00FEAD1A /* ParserCreationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/MiniDOM.swift
+++ b/Sources/MiniDOM.swift
@@ -183,6 +183,17 @@ public extension Node {
         return children.last
     }
 
+    /**
+     Returns an array of children with the given `nodeName`.
+
+     - parameter name: The node name to find.
+
+     - returns: The children with the given node name.
+     */
+    public final func children(withName name: String) -> [Node] {
+        return children.nodes(withName: name)
+    }
+
     /// Returns the `Element` objects from the `children` array.
     public final var childElements: [Element] {
         return self.children(ofType: Element.self)
@@ -201,6 +212,17 @@ public extension Node {
     /// The last element in the `childElements` array.
     public final var lastChildElement: Element? {
         return childElements.last
+    }
+
+    /**
+     Returns an array of child `Element` objects with the given `nodeName`.
+
+     - parameter name: The node name to find.
+
+     - returns: The child elements with the given node name.
+     */
+    public final func childElements(withName name: String) -> [Element] {
+        return children.elements(withName: name)
     }
 }
 

--- a/Sources/NodeList.swift
+++ b/Sources/NodeList.swift
@@ -22,24 +22,47 @@ import Foundation
 public extension Array where Element == Node {
 
     /**
-     Returns only the nodes of the specified type.
+     Returns only the nodes of the given type.
 
      - parameter type: The target type.
 
-     - returns: All members of the receiver that are of the specified type.
+     - returns: All members of the receiver that are of the given type.
      */
     public func only<T: Node>(ofType type: T.Type) -> [T] {
         return self.flatMap { $0 as? T }
     }
 
     /**
-     Returns the first node of the specified type.
+     Returns the first node of the given type.
 
      - parameter type: The target type.
 
-     - returns: The first node of the specified type.
+     - returns: The first node of the given type.
      */
     public func first<T: Node>(ofType type: T.Type) -> T? {
         return first(where: { $0.nodeType == type.nodeType }) as? T
+    }
+
+    /**
+     Returns the objects from the receiver with the given node name.
+     
+     - parameter name: The node name to find.
+     
+     - returns: The nodes from the receiver with the given node name.
+     */
+    public func nodes(withName name: String) -> [Node] {
+        return filter({ $0.nodeName == name })
+    }
+
+    /**
+     Returns the `Element` objects from the receiver with the given node name.
+     
+     - parameter name: The node name to find.
+     
+     - returns: The elements from the receiver with the given node name.
+     */
+    public func elements(withName name: String) -> [MiniDOM.Element] {
+        let elements = only(ofType: MiniDOM.Element.self)
+        return elements.filter({ $0.nodeName == name })
     }
 }

--- a/Tests/MiniDOMTests/NodeTests.swift
+++ b/Tests/MiniDOMTests/NodeTests.swift
@@ -42,4 +42,38 @@ class NodeTests: XCTestCase {
         XCTAssertTrue(element.hasChildren)
         XCTAssertTrue(element.hasChildElements)
     }
+
+    func testChildElements() {
+        let element = Element(tagName: "fnord", children: [
+            Element(tagName: "foo", attributes: ["id": "1"]),
+            Element(tagName: "bar"),
+            Element(tagName: "foo", attributes: ["id": "2"]),
+            Element(tagName: "baz"),
+            Element(tagName: "foo", attributes: ["id": "3"])
+        ])
+
+        let foos = element.childElements(withName: "foo")
+        XCTAssertEqual(foos.count, 3)
+
+        let ids = foos.flatMap({ return $0.attributes?["id"] })
+        XCTAssertEqual(ids.count, 3)
+        XCTAssertEqual(["1", "2", "3"], ids)
+    }
+
+    func testChildrenWithName() {
+        let element = Element(tagName: "fnord", children: [
+            Element(tagName: "foo", attributes: ["id": "1"]),
+            Element(tagName: "bar"),
+            Element(tagName: "foo", attributes: ["id": "2"]),
+            Element(tagName: "baz"),
+            Element(tagName: "foo", attributes: ["id": "3"])
+        ])
+
+        let foos = element.children(withName: "foo")
+        XCTAssertEqual(foos.count, 3)
+
+        let ids = foos.flatMap({ return $0.attributes?["id"] })
+        XCTAssertEqual(ids.count, 3)
+        XCTAssertEqual(["1", "2", "3"], ids)
+    }
 }

--- a/Tests/MiniDOMTests/PathTests.swift
+++ b/Tests/MiniDOMTests/PathTests.swift
@@ -21,7 +21,7 @@ import Foundation
 import MiniDOM
 import XCTest
 
-class PathSimpleTests: XCTestCase {
+class PathTests1: XCTestCase {
     var source: String!
 
     var document: Document!
@@ -62,20 +62,51 @@ class PathSimpleTests: XCTestCase {
         let result = document.evaluate(path: ["a", "b"])
         XCTAssertEqual(result.count, 2)
 
-        let r0 = result[0]
-        XCTAssertEqual(r0.nodeName, "b")
-        XCTAssertEqual(r0.nodeType, NodeType.element)
+        let ids = result.flatMap({ $0.attributes?["id"] })
+        XCTAssertEqual(["2", "10"], ids)
+    }
 
-        let e0 = r0 as? Element
-        XCTAssertNotNil(e0)
-        XCTAssertEqual(e0?.attributes?["id"], "2")
+    func testFindCNodes() {
+        let result = document.evaluate(path: ["a", "b", "c"])
+        XCTAssertEqual(result.count, 3)
 
-        let r1 = result[1]
-        XCTAssertEqual(r1.nodeName, "b")
-        XCTAssertEqual(r1.nodeType, NodeType.element)
+        let ids = result.flatMap({ $0.attributes?["id"] })
+        XCTAssertEqual(["3", "7", "11"], ids)
+    }
+}
 
-        let e1 = r1 as? Element
-        XCTAssertNotNil(e1)
-        XCTAssertEqual(e1?.attributes?["id"], "10")
+class PathTests2: XCTestCase {
+    var source: String!
+
+    var document: Document!
+
+    override func setUp() {
+        super.setUp()
+
+        source = [
+            "<a id='1'>",
+            "  <b id='2'>",
+            "    <fnord id='3'/>",
+            "  </b>",
+            "  <c id='4'>",
+            "    <fnord id='5'/>",
+            "  </c>",
+            "  <b id='6'/>",
+            "  <fnord id='7'/>",
+            "  <b id='8'>",
+            "    <fnord id='9'/>",
+            "  </b>",
+            "</a>",
+        ].joined(separator: "\n")
+
+        document = loadXML(string: source)
+    }
+
+    func testFindFnords() {
+        let result = document.evaluate(path: ["a", "b", "fnord"])
+        XCTAssertEqual(result.count, 2)
+
+        let ids = result.flatMap({ $0.attributes?["id"] })
+        XCTAssertEqual(["3", "9"], ids)
     }
 }

--- a/Tests/MiniDOMTests/TestData/RSSTests.swift
+++ b/Tests/MiniDOMTests/TestData/RSSTests.swift
@@ -38,4 +38,10 @@ class RSSTests: XCTestCase {
         XCTAssertNotNil(titleCdata)
         XCTAssertEqual(titleCdata?.text, "Yahoo! News Search Results for market")
     }
+
+    func testFindItemsInChannel() {
+        let channel = document.evaluate(path: ["rss", "channel"]).first
+        let items = channel?.childElements(withName: "item")
+        XCTAssertEqual(items?.count, 10)
+    }
 }


### PR DESCRIPTION
Rather than visiting the entire tree, evaluate the path by iteratively selecting children with the specified names.

Fixes #8 