### PR TITLE
Streaming

### DIFF
--- a/MiniDOM.xcodeproj/project.pbxproj
+++ b/MiniDOM.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		C5EB9CEE1E7CF12D00198F5F /* ParserResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5EB9CED1E7CF12D00198F5F /* ParserResultTests.swift */; };
 		C5EB9CF01E7CF46800198F5F /* MiniDOMErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5EB9CEF1E7CF46800198F5F /* MiniDOMErrorTests.swift */; };
 		C5EB9CF21E7CF5B900198F5F /* VisitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5EB9CF11E7CF5B900198F5F /* VisitorTests.swift */; };
+		D42EB191270725980030794B /* ParserStreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D42EB190270725980030794B /* ParserStreamTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -96,6 +97,7 @@
 		C5EB9CEF1E7CF46800198F5F /* MiniDOMErrorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MiniDOMErrorTests.swift; sourceTree = "<group>"; };
 		C5EB9CF11E7CF5B900198F5F /* VisitorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VisitorTests.swift; sourceTree = "<group>"; };
 		C5F16D291E908AAA00706AAD /* MiniDOM.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = MiniDOM.playground; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		D42EB190270725980030794B /* ParserStreamTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParserStreamTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -167,6 +169,7 @@
 				C5C88DDA1E7C89BD00CEDDA8 /* ParserPlistTests.swift */,
 				C5EB9CED1E7CF12D00198F5F /* ParserResultTests.swift */,
 				C5C88DD81E7C889200CEDDA8 /* ParserSimpleTests.swift */,
+				D42EB190270725980030794B /* ParserStreamTests.swift */,
 				C5EB9CE31E7CC85700198F5F /* PathTests.swift */,
 				C54E911E2704C41500901FFB /* StringEntityEscapingTests.swift */,
 				C5EB9CE51E7CC94600198F5F /* StringWhitespaceTests.swift */,
@@ -346,6 +349,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C5EB9CF21E7CF5B900198F5F /* VisitorTests.swift in Sources */,
+				D42EB191270725980030794B /* ParserStreamTests.swift in Sources */,
 				C5EB9CF01E7CF46800198F5F /* MiniDOMErrorTests.swift in Sources */,
 				C5796E9F1E8EE3C500FEEBC9 /* NodeTests.swift in Sources */,
 				C56856EA1E88BDF40058EF81 /* ParserNamespaceTests.swift in Sources */,

--- a/Sources/MiniDOM/MiniDOM.swift
+++ b/Sources/MiniDOM/MiniDOM.swift
@@ -230,6 +230,12 @@ public extension Node {
     func childElements(withName name: String) -> [Element] {
         return children.elements(withName: name)
     }
+
+    func normalized() -> Self {
+        var norm = self
+        norm.normalize()
+        return norm
+    }
 }
 
 // MARK: - Leaf Protocol

--- a/Tests/MiniDOMTests/MiniDOMErrorTests.swift
+++ b/Tests/MiniDOMTests/MiniDOMErrorTests.swift
@@ -100,7 +100,7 @@ class MiniDOMErrorTests: XCTestCase {
         let bytes: [UInt8] = [192]
         let invalidUTF8data = Data(bytes)
 
-        let nodeStack = NodeStack()
+        let nodeStack = DocumentParser()
         let xmlParser = AbortDetectingXMLParser()
 
         XCTAssertFalse(xmlParser.parsingAborted)
@@ -134,7 +134,7 @@ class MiniDOMErrorTests: XCTestCase {
 
     func testUnbalancedEndElements() {
         let xmlParser = AbortDetectingXMLParser()
-        let nodeStack = NodeStack()
+        let nodeStack = DocumentParser()
 
         XCTAssertFalse(xmlParser.parsingAborted)
         nodeStack.parser(xmlParser, didEndElement: "fnord", namespaceURI: nil, qualifiedName: nil)
@@ -143,7 +143,7 @@ class MiniDOMErrorTests: XCTestCase {
 
     func testAppendToEmptyStack() {
         let xmlParser = AbortDetectingXMLParser()
-        let nodeStack = NodeStack()
+        let nodeStack = DocumentParser()
 
         XCTAssertFalse(xmlParser.parsingAborted)
         nodeStack.parser(xmlParser, foundComment: "fnord")

--- a/Tests/MiniDOMTests/ParserStreamTests.swift
+++ b/Tests/MiniDOMTests/ParserStreamTests.swift
@@ -1,0 +1,86 @@
+//
+//  ParserStreamTests.swift
+//  MiniDOM
+//
+//  Copyright 2017-2020 Anodized Software, Inc.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a
+//  copy of this software and associated documentation files (the "Software"),
+//  to deal in the Software without restriction, including without limitation
+//  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+//  and/or sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+//  DEALINGS IN THE SOFTWARE.
+//
+
+import Foundation
+import MiniDOM
+import XCTest
+
+class ParserStreamTests: XCTestCase {
+
+    let sourceData = [
+        "<?xml version=\"1.0\" encoding=\"utf-8\"?>",
+        "<foo>",
+        "  <!-- This is a comment -->",
+        "  <bar attr1=\"value1\" attr2=\"value2\"/>",
+        "  <?target attr=\"value\"?>",
+        "  <![CDATA[<div>This is some HTML</div>]]>",
+        "  <baz>",
+        "    <fnord>",
+        "      This is some text",
+        "    </fnord>",
+        "    <fnord attr1=\"value1\">",
+        "      This is some more text",
+        "    </fnord>",
+        "  </baz>",
+        "</foo>"
+    ].joined(separator: "\n").data(using: .utf8)!
+
+    func testFullElementStream() {
+        let parser = Parser(stream: InputStream(data: sourceData))
+
+        var elements = [Element]()
+
+        parser.streamElements { element in
+            elements.append(element)
+            return true
+        } filter: { name in
+            name == "foo" || name == "fnord"
+        }
+
+        XCTAssertEqual(elements.count, 3)
+        XCTAssertEqual(elements[0].tagName, "fnord")
+        XCTAssertEqual(elements[0].textValue?.trimmed, "This is some text")
+        XCTAssertEqual(elements[1].tagName, "fnord")
+        XCTAssertEqual(elements[1].textValue?.trimmed, "This is some more text")
+        XCTAssertEqual(elements[2].tagName, "foo")
+    }
+
+    func testPartialElementStream() {
+        let parser = Parser(stream: InputStream(data: sourceData))
+
+        var foundElement: Element?
+
+        parser.streamElements { element in
+            foundElement = element
+            return false
+        } filter: { name in
+            name == "bar"
+        }
+
+        XCTAssertNotNil(foundElement)
+        XCTAssertEqual(foundElement?.tagName, "bar")
+        XCTAssertEqual(foundElement?.children.count, 0)
+    }
+}


### PR DESCRIPTION
Added new API to `Parser` to support streaming elements without assembling the entire `Document`. This addresses two use cases:
1. The full XML document is too large to fit in memory.
2. Searching for a particular element (or set of elements) and terminating the parse once found.